### PR TITLE
Retain visits between re-caching of data from data source

### DIFF
--- a/src/Alfred/Cache.hs
+++ b/src/Alfred/Cache.hs
@@ -1,11 +1,31 @@
 module Alfred.Cache
     ( writeItems
+    , rawWriteItems
     ) where
 
 import qualified Data.Csv as Csv
 import qualified Data.ByteString.Lazy as BS
+import qualified Data.Foldable as F
 
 import Alfred.Item
+import Alfred.Search
 
 writeItems :: String -> [Item] -> IO ()
-writeItems cacheFile = BS.writeFile cacheFile . Csv.encodeDefaultOrderedByName
+writeItems cacheFile items = do
+  cachedItems <- getItems cacheFile
+  rawWriteItems cacheFile $ itemsWithCachedVisits items cachedItems
+
+rawWriteItems :: String -> [Item] -> IO ()
+rawWriteItems cacheFile = BS.writeFile cacheFile . Csv.encodeDefaultOrderedByName
+
+itemsWithCachedVisits :: Foldable t => [Item] -> t Item -> [Item]
+itemsWithCachedVisits currentItems itemsCache =
+  map (combineWithCache itemsCache) currentItems
+
+combineWithCache :: Foldable t => t Item -> Item -> Item
+combineWithCache is i =
+  case item of
+    Just i' -> i { aiVisits = aiVisits i' }
+    Nothing -> i
+  where
+    item = F.find ((== aiUrl i) . aiUrl) is

--- a/src/Alfred/Increment.hs
+++ b/src/Alfred/Increment.hs
@@ -12,7 +12,7 @@ incrementVisits :: String -> T.Text -> IO ()
 incrementVisits cacheFile url = do
     items <- getItems cacheFile
     let items' = foldr (incrementIfItem url) [] items
-    writeItems cacheFile items'
+    rawWriteItems cacheFile items'
 
 incrementIfItem :: T.Text -> Item -> [Item] -> [Item]
 incrementIfItem url item items


### PR DESCRIPTION
## Why?

We need to periodically update data, but previously, the update would
wipe out visits count metadata. This introduces another step when
importing data by retaining visits from the current cache before
overwriting the results with the latest batch of data from the server.

It does so with Data.HashMap.Strict, (perhaps naively) using the URL as
the key.
